### PR TITLE
docs: add Windows installation tutorial link

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -189,6 +189,10 @@ Este comando comprimirá `video.mp4` con una calidad de 80, guardará el resulta
 > Si eres usuario de Windows, puedes instalar `ffmpeg` y `python` manualmente o usando gestores de paquetes como [*`Scoop`*][scoop].
 > Una vez que hayas instalado un gestor de paquetes, solo debes ejecutar algo como `scoop install python ffmpeg`.
 
+<!-- -->
+> [!TIP]
+> Los usuarios de Windows pueden ver un video tutorial en YouTube sobre el proceso de instalación [[Aquí]][demo-windows].
+
 ## Contribuidores
 
 <a href="https://github.com/ivansaul/CLI-Video-Compressor/graphs/contributors">
@@ -205,3 +209,4 @@ Este comando comprimirá `video.mp4` con una calidad de 80, guardará el resulta
 [ffmpeg]:https://ffmpeg.org
 [demo]:https://github.com/user-attachments/assets/9c9c672a-bfa3-418a-b7d1-89f0e7751146
 [scoop]:https://scoop.sh
+[demo-windows]: https://youtu.be/w1Pba7Bu0ZQ

--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ This command will compress `video.mp4` with a quality of 80, save the result as 
 > If you are a Windows user, you can install `ffmpeg` and `python` manually or using package managers like [*`Scoop`*][scoop].
 > Once you have installed a package manager, you can just run something like `scoop install python ffmpeg`.
 
+<!-- -->
+> [!TIP]
+> Windows user can watch a tutorial video on YouTube about the installation process [[Here]][demo-windows].
+
 ## Contributors
 
 <a href="https://github.com/ivansaul/CLI-Video-Compressor/graphs/contributors">
@@ -205,3 +209,4 @@ This command will compress `video.mp4` with a quality of 80, save the result as 
 [ffmpeg]:https://ffmpeg.org
 [demo]:https://github.com/user-attachments/assets/9c9c672a-bfa3-418a-b7d1-89f0e7751146
 [scoop]:https://scoop.sh
+[demo-windows]: https://youtu.be/w1Pba7Bu0ZQ


### PR DESCRIPTION
Adds a link to a YouTube tutorial for installing the necessary software on Windows. This makes it easier for Windows users to get started with the CLI Video Compressor.